### PR TITLE
insert spaces for TextElement distances slightly less than width_of_space

### DIFF
--- a/lib/tabula/entities.rb
+++ b/lib/tabula/entities.rb
@@ -120,6 +120,7 @@ module Tabula
     attr_accessor :font, :font_size, :text, :width_of_space
 
     CHARACTER_DISTANCE_THRESHOLD = 1.5
+    TOLERANCE_FACTOR = 0.25
 
     def initialize(top, left, width, height, font, font_size, text, width_of_space)
       super(top, left, width, height)
@@ -134,7 +135,7 @@ module Tabula
       raise TypeError, "argument is not a TextElement" unless other.instance_of?(TextElement)
       overlaps = self.vertically_overlaps?(other)
 
-      tolerance = ((self.font_size + other.font_size) / 2) * 0.25
+      tolerance = ((self.font_size + other.font_size) / 2) * TOLERANCE_FACTOR
 
       overlaps or
         (self.height == 0 and other.height != 0) or
@@ -147,10 +148,12 @@ module Tabula
       raise TypeError, "argument is not a TextElement" unless other.instance_of?(TextElement)
       overlaps = self.vertically_overlaps?(other)
 
-      tolerance = ((self.font_size + other.font_size) / 2) * 0.25
+      up_tolerance = ((self.font_size + other.font_size) / 2) * TOLERANCE_FACTOR
+      down_tolerance = 0.95
 
       dist = self.horizontal_distance(other).abs
-      rv = overlaps && (dist.between?(self.width_of_space, self.width_of_space + tolerance))
+      
+      rv = overlaps && (dist.between?(self.width_of_space * down_tolerance, self.width_of_space + up_tolerance))
       rv
     end
 


### PR DESCRIPTION
I found part of the problem with spaces not being inserted that I'd had in tabula-extractor. Some distances between text_elements in `should_add_space?` are reporting themselves as a little less than width_of_space when (from a human perspective) there ought to be a space.

this could be  
1. a pdfbox bug,  
2. a conceptual problem we have where the width_of_space changes in the document
3. kerning 
4.  something else entirely

e.g. I'm getting distances in the frx test document (in the table-detection branch) of 1.6399999999999864 with width_of_space 1.668
so a space isn't inserted because 1.64 < 1.668

this PR fixes the problem by inserting a space when the distance is between 95% of width_of_space and width_of_space plus the threshold. 95% wasn't reached scientifically, but gives perfect results empirically.
