### PR TITLE
suppress those goddamn INFO logs from pdfbox #killthemwithfire

### DIFF
--- a/lib/tabula.rb
+++ b/lib/tabula.rb
@@ -2,6 +2,22 @@ module Tabula
   PDFBOX = 'pdfbox-app-2.0.0-SNAPSHOT.jar'
 end
 
+
+import 'java.util.logging.LogManager'
+import 'java.util.logging.Level'
+
+lm = LogManager.log_manager
+lm.logger_names.each do |name|
+  if name == "" #rootlogger is apparently the logger PDFBox is talking to.
+    l = lm.get_logger(name)
+    l.level = Level::OFF
+    l.handlers.each do |h|
+      h.level = Level::OFF
+    end
+  end
+end
+
+
 require_relative './tabula/version'
 require_relative './tabula/entities'
 require_relative './tabula/pdf_dump'


### PR DESCRIPTION
JRuby is the work of the devil.

JRuby is the spawn of Satan.

But through liberal application of holy water, fire, garlic, a silver bullet and Googling that which should never be Googled, I managed to figure out how to suppress those damn INFO logs that PDFBox keeps emitting. I don't know if there is a better way (other than implementing log4j, which seems a bit heavy) -- or if those INFO logs are useful to you, Manuel, and ought to be able to be turned on/off somewhere. But this does it.

I've seen things that no org.java.mortal ought to see.
