### PR TITLE
Fix Rake failure in projects importing tabula-extractor

### DIFF
--- a/lib/tabula.rb
+++ b/lib/tabula.rb
@@ -9,8 +9,8 @@ require File.join(File.dirname(__FILE__), '../target/', 'slf4j-api-1.6.3.jar')
 require File.join(File.dirname(__FILE__), '../target/', 'trove4j-3.0.3.jar')
 require File.join(File.dirname(__FILE__), '../target/', 'jsi-1.1.0-SNAPSHOT.jar')
 
-import 'java.util.logging.LogManager'
-import 'java.util.logging.Level'
+java_import 'java.util.logging.LogManager'
+java_import 'java.util.logging.Level'
 
 lm = LogManager.log_manager
 lm.logger_names.each do |name|


### PR DESCRIPTION
In projects importing tabula-extractor, running `rake test` terminated with `NameError: uninitialized constant LogManager` because the class `java.util.logging.LogManager` was imported with `import` instead of `java_import`. `java.util.logging.Level`, on the following line, was also imported with `import` and caused the same error after the `LogManager` error was fixed. Searching tabula-extractor, these were the only uses of `import`. `java_import` is used throughout the rest of the project. `rake test` ran as expected after replacing both `import` statements with `java_import`.

References:
- Using a Java Class Without The Full Path Name
  https://github.com/jruby/jruby/wiki/CallingJavaFromJRuby#using-a-java-class-without-the-full-path-name
- loading rake breaks import
  http://jira.codehaus.org/browse/JRUBY-3171
