### PR TITLE
Fix `ambiguous Java methods found` warning for java.util.TreeMap

### DIFF
--- a/lib/tabula/entities/ruling.rb
+++ b/lib/tabula/entities/ruling.rb
@@ -194,7 +194,8 @@ module Tabula
     # log(n) implementation of find_intersections
     # based on http://people.csail.mit.edu/indyk/6.838-old/handouts/lec2.pdf
     def self.find_intersections(horizontals, verticals)
-      tree = java.util.TreeMap.new(HSegmentComparator.new)
+      construct_treemap_t_comparator = java.util.TreeMap.java_class.constructor(java.util.Comparator)
+      tree = construct_treemap_t_comparator.new_instance(HSegmentComparator.new).to_java
       sort_obj = Struct.new(:type, :pos, :obj)
 
       (horizontals + verticals)


### PR DESCRIPTION
When running `rake test`, the `find_intersections` method of the `Ruling` class raised `warning: ambiguous Java methods found, using java.util.TreeMap(java.util.Comparator)`. Although the `new` method of `java.util.TreeMap` selects the correct constructor, `TreeMap(Comparator<? super K> comparator)`, this warning was fixed by 'select[ing] a particular constructor by signature use reflection'.

References:
- Constructors
  https://github.com/jruby/jruby/wiki/CallingJavaFromJRuby#constructors
- Class TreeMap<K,V>
  http://docs.oracle.com/javase/8/docs/api/java/util/TreeMap.html
