### PR TITLE
notes first page that has text elements in pages JSON

### DIFF
--- a/lib/tabula/entities/page.rb
+++ b/lib/tabula/entities/page.rb
@@ -191,6 +191,10 @@ module Tabula
       end
     end
 
+    def has_text?
+      !self.texts.empty?
+    end
+
     # TODO no need for this, let's choose one name
     def ruling_lines
       get_ruling_lines!
@@ -258,7 +262,7 @@ module Tabula
         :height => self.height,
         :number => self.number,
         :rotation => self.rotation,
-        :texts => self.texts
+        :hasText => self.has_text?
       }.to_json(options)
     end
 


### PR DESCRIPTION
also remove texts key, since nothing used it and it was always empty

I'm PRing this in case there are unanticipated performance hits to using an object extractor in page metadata extraction (but only until we find a page with real text, then we stop.)