### PR TITLE
Correct table extraction examples in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ extractor.extract.each_with_index do |pdf_page, page_index|
   page_areas = [[250, 0, 325, 1700]]
 
   page_areas.each do |page_area|
-    out << pdf_page.get_area(page_area).make_table.to_csv
+    out << pdf_page.get_area(page_area).get_table.to_csv
     out << "\n\n"
   end
 
@@ -155,7 +155,7 @@ extractor.extract.each_with_index do |pdf_page, page_index|
   vertical_rulings = vertical_ruling_locations.map{|n| Tabula::Ruling.new(0, n * scale_factor, 0, 1000)}
 
   page_areas.each do |page_area|
-    out << pdf_page.get_area(page_area).make_table(:vertical_rulings => vertical_rulings).to_csv
+    out << pdf_page.get_area(page_area).get_table(:vertical_rulings => vertical_rulings).to_csv
     out << "\n\n"
   end
 end


### PR DESCRIPTION
make_table returns the raw rows, get_table returns a table object.
The Array#to_csv method ends up calling the TextChunk#inspect method,
which produces unexpected output.
